### PR TITLE
Sample configuration should contain easier-to-work-with configs (#26)

### DIFF
--- a/app/config.js.sample
+++ b/app/config.js.sample
@@ -5,7 +5,7 @@
  */
 const config = {
     apiUrl: `/api/v2/`,
-    vidiUrl: `http://127.0.0.1:3000/app/`
+    vidiUrl: `VIDI_URL_CONFIGURATION`
 };
 
 export default config;


### PR DESCRIPTION
Please see the https://github.com/sashuk/gc2_aks/commit/d15df90c8f25c2d4b6349ac224930c91390adb10 for better understanding - now the ConfigMap for the `gc2core` pod sets the Vidi URL as well